### PR TITLE
ParseGemespec::Specification#to_hash_object

### DIFF
--- a/lib/parse_gemspec/specification.rb
+++ b/lib/parse_gemspec/specification.rb
@@ -12,7 +12,7 @@ module ParseGemspec
       @spec = spec
     end
 
-    def format(format: {}) # rubocop:disable Lint/UnusedMethodArgument
+    def to_hash_object(format: {}) # rubocop:disable Lint/UnusedMethodArgument
       {
         name: name,
         version: version.version,

--- a/lib/parse_gemspec/specification.rb
+++ b/lib/parse_gemspec/specification.rb
@@ -12,10 +12,7 @@ module ParseGemspec
       @spec = spec
     end
 
-    def format(output_format: {})
-      # avoid rubocop warn
-      output_format.nil?
-
+    def format(format: {}) # rubocop:disable Lint/UnusedMethodArgument
       {
         name: name,
         version: version.version,

--- a/test/test_specification.rb
+++ b/test/test_specification.rb
@@ -14,9 +14,10 @@ module ParseGemspec
         version: '1.2.7',
         homepage: 'http://www.ruby-lang.org'
       }
+      spec = ParseGemspec::Specification.load(gemspec_path)
       test '.format' do
         assert do
-          ParseGemspec::Specification.load(gemspec_path).format == expected
+          spec.to_hash_object == expected
         end
       end
     end
@@ -32,9 +33,10 @@ module ParseGemspec
         version: '0.1.2.pre.beta',
         homepage: 'https://github.com/packsaddle/rubocop-select'
       }
+      spec = ParseGemspec::Specification.load(gemspec_path)
       test '.format' do
         assert do
-          ParseGemspec::Specification.load(gemspec_path).format == expected
+          spec.to_hash_object == expected
         end
       end
     end
@@ -50,9 +52,10 @@ module ParseGemspec
         version: '1.0.2',
         homepage: 'https://github.com/packsaddle/ruby-checkstyle_filter-git'
       }
+      spec = ParseGemspec::Specification.load(gemspec_path)
       test '.format' do
         assert do
-          ParseGemspec::Specification.load(gemspec_path).format == expected
+          spec.to_hash_object == expected
         end
       end
     end


### PR DESCRIPTION
- There is `Kernel.format`.
- Breaking change.
